### PR TITLE
Allow the configuration of a HTTP proxy

### DIFF
--- a/charts/registry-creds/templates/deployment.yaml
+++ b/charts/registry-creds/templates/deployment.yaml
@@ -85,6 +85,14 @@ spec:
                 name: {{ .Release.Name }}-acr
                 key: ACR_PASSWORD
         {{ end }}
+        {{ if .Values.httpProxy }}
+          - name: HTTP_PROXY
+            value: {{ .Values.httpProxy.url }}
+          - name: HTTPS_PROXY
+            value: {{ .Values.httpProxy.url }}
+          - name: NO_PROXY
+            value: {{ default "" .Values.httpProxy.noProxy }}
+        {{ end }}
       {{ if .Values.gcr }}
         volumeMounts:
         - name: gcr-creds

--- a/charts/registry-creds/values.yaml
+++ b/charts/registry-creds/values.yaml
@@ -47,3 +47,10 @@ image:
 #  # password the password for the azure client
 #  password: foo
 #
+
+# httpProxy provides a way to proxy http/https requests as required in some environemnts
+#httpProxy:
+#  # url is the URL of the proxy server
+#  url: http://proxy.example.com:8080
+#  # noProxy is a comma separated list of hosts that should not be proxied
+#  noProxy: localhost


### PR DESCRIPTION
In certain environments it is preferable or even mandatory to make http/https requests via a proxy. This changes exposes the required configuration variables.