### PR TITLE
fix default empty values not present in the secret

### DIFF
--- a/charts/registry-creds/templates/secret.yaml
+++ b/charts/registry-creds/templates/secret.yaml
@@ -24,12 +24,12 @@ metadata:
     app: {{ .Release.Name }}
     cloud: ecr
 data:
-  AWS_ACCESS_KEY_ID: {{ .Values.ecr.accessKeyID | b64enc }}
-  AWS_SECRET_ACCESS_KEY: {{ .Values.ecr.secretAccessKey | b64enc }}
-  AWS_SESSION_TOKEN: {{ default "" .Values.ecr.sessionToken | b64enc }}
-  aws-account: {{ .Values.ecr.account | b64enc }}
-  aws-region: {{ .Values.ecr.region | b64enc }}
-  aws-assume-role: {{ default "" .Values.ecr.assumeRole | b64enc }}
+  AWS_ACCESS_KEY_ID: {{ .Values.ecr.accessKeyID | b64enc | quote }}
+  AWS_SECRET_ACCESS_KEY: {{ .Values.ecr.secretAccessKey | b64enc | quote }}
+  AWS_SESSION_TOKEN: {{ default "" .Values.ecr.sessionToken | b64enc | quote }}
+  aws-account: {{ .Values.ecr.account | b64enc | quote }}
+  aws-region: {{ .Values.ecr.region | b64enc | quote }}
+  aws-assume-role: {{ default "" .Values.ecr.assumeRole | b64enc | quote }}
 type: Opaque
 {{ end }}
 ---


### PR DESCRIPTION
I didn't dig deep enough to find out the root cause of this. The issue was that on helm install, the `AWS_SESSION_TOKEN` and `aws-assume-role` would be correctly present in the secret with an empty string as the value, however after a helm update with the same values, those keys would be completely removed from the secret. 
Quoting it fixes the issue. My guess is that something is being passed as a nil probably from the b64enc and either helm or k8s is not including the field